### PR TITLE
JavaScript uitzetten breekt functionaliteit

### DIFF
--- a/opdracht5/src/js/main.js
+++ b/opdracht5/src/js/main.js
@@ -6,10 +6,9 @@
 
 	var app = {
 		init: function() {
-
+			
 			// call the routes.init
 			routes.init();
-
 		}
 	}
 
@@ -20,7 +19,6 @@
 			window.addEventListener('hashchange', sections.toggle ,false);
 			// also check the page on load
 			window.addEventListener('load', sections.toggle ,false);
-
 		}
 	}
 
@@ -32,36 +30,29 @@
 
 			// If the url has a hash
 			if ( url ) {
-
 				//NOTE: Got the templateing idea from Dylan Vens
-
 				// Get the template that matches the url
 				var matchingTemplate = document.querySelector(url);
 
 				// If this templates exists
 				if ( matchingTemplate ) {
-
+	
 					// Get the content from the matching template and use that content in the main html
 					main.innerHTML = matchingTemplate.innerHTML;
-
 				} else {
 
 					// If the template doesn't exists: load the error template
 					main.innerHTML = document.querySelector('#error').innerHTML;
-
 				}
-
+				
 			} else {
 				
 				// If the url has no hash(so this is home) -> set the hash to start
 				window.location.hash = '#home';
-
 			} 
-
 		}
 	}
-
+	
 	// start the main app
 	app.init();
-
 })();


### PR DESCRIPTION
Door het gebruik van de templates (en vooral dat de sections standaard op display none staan) en het aanpassen van de innerHTML werkt de code alleen als JavaScript aan staat. Maar als deze niet werkt moet de gebruiker alle content kunnen zien, anders hebben ze namelijk een lege pagina.

Ik zou de secties standaard een display block meegeven, en toggle via javascript dan een class, die de secties wisselt tussen "none" en "block";
Op deze manier heb je de functionaliteit die je wilt en is de content ook zichtbaar zonder JS.

Ik vind het wel een interessante aanpak, vooral omdat je nu ook een error pagina laat zien als iemand de hashtag handmatig verkeerd verandert. Maar nu gaat het ten koste van de content.
